### PR TITLE
Improve category and rule management

### DIFF
--- a/core/categorize.py
+++ b/core/categorize.py
@@ -22,7 +22,7 @@ def create_rule_from_tx(tx_id: int, category_id: int, match_type='contains', fie
         pattern = (tx.counterparty or '').strip()
         if field == 'reference':
             pattern = (tx.reference or '').strip()
-        r = Rule(category_id=category_id, field=field, match_type=match_type, pattern=pattern, priority=100)
+        r = Rule(category_id=category_id, field=field, match_type=match_type, pattern=pattern)
         s.add(r)
         s.flush()
         return r.id

--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -46,3 +46,21 @@ else:
         .properties(height=420, title=f"Expenses for {selected_month}")
     )
     st.altair_chart(chart, use_container_width=True)
+
+    st.markdown("### Thresholds")
+    for cat in selected:
+        st.number_input(
+            f"{cat} threshold",
+            value=0.0,
+            step=10.0,
+            key=f"th_{selected_month}_{cat}",
+        )
+    df_month["threshold"] = df_month["category"].map(
+        lambda c: st.session_state.get(f"th_{selected_month}_{c}", 0.0)
+    )
+    df_month["over"] = df_month["total"] > df_month["threshold"]
+    st.dataframe(
+        df_month[["category", "total", "threshold", "over"]],
+        use_container_width=True,
+        hide_index=True,
+    )

--- a/pages/3_Categories_and_Rules.py
+++ b/pages/3_Categories_and_Rules.py
@@ -1,33 +1,43 @@
 import streamlit as st
 import pandas as pd
-from sqlalchemy import select
 from core.db import get_session
 from core.models import Category, Rule
-from core.rules import apply_rules_to_uncategorized
+from core.rules import (
+    apply_rules_to_all,
+    apply_rule_to_all_transactions,
+)
 
 st.title("Categories & Rules")
 
 st.subheader("Categories")
 with get_session() as s:
     cats = s.query(Category).order_by(Category.name.asc()).all()
-    df = pd.DataFrame([{'id': c.id, 'name': c.name, 'description': c.description, 'threshold': c.threshold_amount, 'active': c.is_active} for c in cats])
+    df = pd.DataFrame(
+        [
+            {
+                "id": c.id,
+                "name": c.name,
+                "description": c.description,
+                "active": c.is_active,
+            }
+            for c in cats
+        ]
+    )
     st.dataframe(df, use_container_width=True, hide_index=True)
 
 with st.expander("Add / Update Category"):
     name = st.text_input("Name")
     desc = st.text_area("Description", value="", height=60)
-    th = st.number_input("Threshold amount (optional)", value=0.0, step=10.0)
     active = st.checkbox("Active", value=True)
     if st.button("Save Category"):
         with get_session() as s:
             c = s.query(Category).filter(Category.name == name).one_or_none()
             if c:
                 c.description = desc
-                c.threshold_amount = th if th > 0 else None
                 c.is_active = active
                 st.success("Category updated")
             else:
-                s.add(Category(name=name, description=desc, threshold_amount=(th if th>0 else None), is_active=active))
+                s.add(Category(name=name, description=desc, is_active=active))
                 st.success("Category added")
 
 st.divider()
@@ -57,7 +67,14 @@ if file is not None and st.button("Import & Seed Rules"):
                 if providers:
                     for p in [x.strip() for x in providers.split(',') if x.strip()]:
                         # create 'contains' rule on counterparty
-                        s.add(Rule(category_id=c.id, field='counterparty', match_type='contains', pattern=p, priority=100))
+                        s.add(
+                            Rule(
+                                category_id=c.id,
+                                field="counterparty",
+                                match_type="contains",
+                                pattern=p,
+                            )
+                        )
                         added_rules += 1
         st.success(f"Imported. Added categories: {added_cats}, rules: {added_rules}")
         st.info("Go to Transactions → Re-apply rules (ingest a CSV first).")
@@ -65,19 +82,30 @@ if file is not None and st.button("Import & Seed Rules"):
 st.divider()
 st.subheader("Rules")
 with get_session() as s:
-    rules = s.query(Rule).order_by(Rule.enabled.desc(), Rule.priority.asc()).all()
-    df = pd.DataFrame([{
-        'id': r.id, 'category_id': r.category_id, 'field': r.field, 'type': r.match_type,
-        'pattern': r.pattern, 'priority': r.priority, 'enabled': r.enabled
-    } for r in rules])
+    rules = s.query(Rule).order_by(Rule.enabled.desc(), Rule.id.asc()).all()
+    df = pd.DataFrame(
+        [
+            {
+                "id": r.id,
+                "category_id": r.category_id,
+                "category": r.category.name if r.category else None,
+                "field": r.field,
+                "type": r.match_type,
+                "pattern": r.pattern,
+                "enabled": r.enabled,
+            }
+            for r in rules
+        ]
+    )
     st.dataframe(df, use_container_width=True, hide_index=True)
 
 with st.expander("Add Rule"):
-    cat_name = st.text_input("Category name for the rule")
+    with get_session() as s:
+        cat_options = [c.name for c in s.query(Category).order_by(Category.name.asc()).all()]
+    cat_name = st.selectbox("Category", options=cat_options)
     field = st.selectbox("Field", options=['counterparty', 'reference'])
     mtype = st.selectbox("Match type", options=['contains', 'exact', 'regex', 'fuzzy'])
     pattern = st.text_input("Pattern")
-    priority = st.number_input("Priority (lower is stronger)", value=100, step=1)
     if st.button("Save Rule"):
         with get_session() as s:
             c = s.query(Category).filter(Category.name == cat_name).one_or_none()
@@ -85,6 +113,32 @@ with st.expander("Add Rule"):
                 st.error("Category not found")
             else:
                 from core.models import Rule
-                s.add(Rule(category_id=c.id, field=field, match_type=mtype, pattern=pattern, priority=int(priority)))
+                s.add(Rule(category_id=c.id, field=field, match_type=mtype, pattern=pattern))
                 st.success("Rule added")
+
+st.markdown(
+    """
+**How to add a rule:**
+* **Match types**
+    * *contains* – pattern must appear in the field
+    * *exact* – field must exactly match the pattern
+    * *regex* – pattern is a regular expression
+    * *fuzzy* – allows minor differences
+* To disable a rule set its `enabled` flag to `False` in the database.
+* Example: pattern `Uber` with match type `contains` matches any counterparty containing "Uber".
+    """
+)
+
+st.divider()
+st.subheader("Apply Rules")
+
+if st.button("Apply all rules to all transactions"):
+    changed = apply_rules_to_all()
+    st.success(f"Rules applied to {changed} transactions")
+
+rule_map = {f"#{r.id} {r.field}:{r.pattern}": r.id for r in rules}
+selected_rule = st.selectbox("Rule to apply to all transactions", options=list(rule_map.keys()))
+if st.button("Apply selected rule"):
+    count = apply_rule_to_all_transactions(rule_map[selected_rule])
+    st.success(f"Rule applied to {count} transactions")
 


### PR DESCRIPTION
## Summary
- Drop threshold column from category management and move threshold inputs to Dashboard
- Simplify rule handling: remove priority, show category names, and add instructions
- Add utilities to apply all rules or a selected rule to every transaction

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f285d009c8330b1b4a12ff458881d