### PR TITLE
Add amount-based rule conditions and rule management UI

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -34,6 +34,8 @@ class Rule(Base):
     field: Mapped[str] = mapped_column(String(20))  # 'counterparty' | 'reference'
     match_type: Mapped[str] = mapped_column(String(20))  # 'exact' | 'contains' | 'regex' | 'fuzzy'
     pattern: Mapped[str] = mapped_column(Text)
+    amount_min: Mapped[float | None] = mapped_column(Float, nullable=True)
+    amount_max: Mapped[float | None] = mapped_column(Float, nullable=True)
     priority: Mapped[int] = mapped_column(Integer, default=100)
     case_sensitive: Mapped[bool] = mapped_column(Boolean, default=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/core/rules.py
+++ b/core/rules.py
@@ -38,6 +38,10 @@ def choose_category_for(tx: Transaction, rules: Iterable[Rule]) -> Optional[tupl
         [r for r in rules if r.enabled], key=lambda r: order.get(r.match_type, 9)
     )
     for r in sorted_rules:
+        if r.amount_min is not None and tx.amount < r.amount_min:
+            continue
+        if r.amount_max is not None and tx.amount > r.amount_max:
+            continue
         value = _field_value(tx, r.field)
         if not value:
             continue
@@ -107,6 +111,10 @@ def apply_rule_to_all_transactions(rule_id: int):
         count = 0
         for tx in txs:
             if tx.is_income:
+                continue
+            if rule.amount_min is not None and tx.amount < rule.amount_min:
+                continue
+            if rule.amount_max is not None and tx.amount > rule.amount_max:
                 continue
             value = _field_value(tx, rule.field)
             if not value:


### PR DESCRIPTION
## Summary
- Allow rules to include optional transaction amount ranges and respect them during rule application
- Prevent duplicate rules when importing Categories.xlsx
- Expose amount range fields and enable/disable/delete actions in the rules UI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f360a38408330b286d1ca423bf98c