### PR TITLE
Add Google Drive CSV import/export for transactions, categories, and rules

### DIFF
--- a/core/gdrive.py
+++ b/core/gdrive.py
@@ -1,0 +1,70 @@
+"""Utilities for uploading and downloading CSV files to Google Drive."""
+
+from __future__ import annotations
+
+import io
+from typing import Optional
+
+import pandas as pd
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
+
+from .gdrive_config import CREDENTIALS_FILE, FOLDER_ID
+
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+def _drive_service():
+    creds = service_account.Credentials.from_service_account_file(
+        CREDENTIALS_FILE, scopes=SCOPES
+    )
+    return build("drive", "v3", credentials=creds)
+
+
+def upload_df(df: pd.DataFrame, filename: str) -> Optional[str]:
+    """Upload a DataFrame as CSV to Google Drive.
+
+    Returns the file ID if successful.
+    """
+    service = _drive_service()
+    file_metadata = {"name": filename}
+    if FOLDER_ID:
+        file_metadata["parents"] = [FOLDER_ID]
+    stream = io.BytesIO(df.to_csv(index=False).encode("utf-8"))
+    media = MediaIoBaseUpload(stream, mimetype="text/csv")
+    file = (
+        service.files()
+        .create(body=file_metadata, media_body=media, fields="id")
+        .execute()
+    )
+    return file.get("id")
+
+
+def download_df(filename: str) -> Optional[pd.DataFrame]:
+    """Download a CSV from Google Drive into a DataFrame.
+
+    Looks for a file with the given name inside the configured folder.
+    Returns ``None`` if the file is not found.
+    """
+    service = _drive_service()
+    query = f"name='{filename}'"
+    if FOLDER_ID:
+        query += f" and '{FOLDER_ID}' in parents"
+    results = (
+        service.files()
+        .list(q=query, spaces="drive", fields="files(id,name)", pageSize=1)
+        .execute()
+    )
+    items = results.get("files", [])
+    if not items:
+        return None
+    file_id = items[0]["id"]
+    request = service.files().get_media(fileId=file_id)
+    fh = io.BytesIO()
+    downloader = MediaIoBaseDownload(fh, request)
+    done = False
+    while not done:
+        _, done = downloader.next_chunk()
+    fh.seek(0)
+    return pd.read_csv(fh)

--- a/core/gdrive_config.py
+++ b/core/gdrive_config.py
@@ -1,0 +1,9 @@
+"""Configuration for Google Drive integration."""
+
+import os
+
+# Path to service account credentials JSON file
+CREDENTIALS_FILE = os.getenv("GDRIVE_CREDENTIALS_FILE", "gdrive_credentials.json")
+
+# Folder ID in Google Drive where CSV files are stored
+FOLDER_ID = os.getenv("GDRIVE_FOLDER_ID", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ python-dateutil>=2.9
 rapidfuzz>=3.9
 altair>=5.3
 openpyxl>=3.1
+google-api-python-client>=2.100
+google-auth>=2.20


### PR DESCRIPTION
## Summary
- add helper modules for Google Drive auth and CSV upload/download
- export/import transactions, categories, and rules via new Drive buttons
- document Google API dependencies

## Testing
- `python -m py_compile core/gdrive_config.py core/gdrive.py pages/2_Transactions.py pages/3_Categories_and_Rules.py`
- ⚠️ `pip install google-api-python-client google-auth` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f80fca2988330bcfda2bd5a0aec61