### PR TITLE
Fix Google Drive table import/export column names

### DIFF
--- a/pages/2_Transactions.py
+++ b/pages/2_Transactions.py
@@ -60,7 +60,15 @@ else:
 
     up_col, down_col = st.columns(2)
     if up_col.button("Upload to Drive"):
-        gdrive.upload_df(df, "transactions.csv")
+        export_map = {
+            'id': 'ID',
+            'date': 'Completed date',
+            'counterparty': 'Counterparty name',
+            'reference': 'Reference',
+            'amount': 'Amount',
+            'category': 'Category',
+        }
+        gdrive.upload_df(df.rename(columns=export_map), "transactions.csv")
         st.success("Uploaded transactions to Google Drive")
     if down_col.button("Download from Drive"):
         drive_df = gdrive.download_df("transactions.csv")

--- a/pages/3_Categories_and_Rules.py
+++ b/pages/3_Categories_and_Rules.py
@@ -28,13 +28,21 @@ with get_session() as s:
 
     c_up, c_down = st.columns(2)
     if c_up.button("Upload Categories to Drive"):
-        gdrive.upload_df(df, "categories.csv")
+        export_map = {
+            "id": "ID",
+            "name": "Name",
+            "description": "Description",
+            "active": "Active",
+        }
+        gdrive.upload_df(df.rename(columns=export_map), "categories.csv")
         st.success("Categories uploaded to Google Drive")
     if c_down.button("Download Categories from Drive"):
         drive_df = gdrive.download_df("categories.csv")
         if drive_df is None:
             st.error("categories.csv not found on Drive")
         else:
+            rev_map = {"ID": "id", "Name": "name", "Description": "description", "Active": "active"}
+            drive_df = drive_df.rename(columns=rev_map)
             with get_session() as s:
                 for _, r in drive_df.iterrows():
                     name = str(r.get("name", "")).strip()
@@ -137,13 +145,36 @@ with get_session() as s:
 
     r_up, r_down = st.columns(2)
     if r_up.button("Upload Rules to Drive"):
-        gdrive.upload_df(df, "rules.csv")
+        export_map = {
+            "id": "ID",
+            "category_id": "Category ID",
+            "category": "Category",
+            "field": "Field",
+            "type": "Type",
+            "pattern": "Pattern",
+            "amount_min": "Amount Min",
+            "amount_max": "Amount Max",
+            "enabled": "Enabled",
+        }
+        gdrive.upload_df(df.rename(columns=export_map), "rules.csv")
         st.success("Rules uploaded to Google Drive")
     if r_down.button("Download Rules from Drive"):
         drive_df = gdrive.download_df("rules.csv")
         if drive_df is None:
             st.error("rules.csv not found on Drive")
         else:
+            rev_map = {
+                "ID": "id",
+                "Category ID": "category_id",
+                "Category": "category",
+                "Field": "field",
+                "Type": "type",
+                "Pattern": "pattern",
+                "Amount Min": "amount_min",
+                "Amount Max": "amount_max",
+                "Enabled": "enabled",
+            }
+            drive_df = drive_df.rename(columns=rev_map)
             with get_session() as s:
                 for _, r in drive_df.iterrows():
                     rid = r.get("id")


### PR DESCRIPTION
## Summary
- Rename exported transaction columns to match ingest format for re-import
- Export rules and categories with human-readable headers and map them back on import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f98edafa48330842e1da6cea361d5